### PR TITLE
timeout increased

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --testTimeout=20000"
   },
   "dependencies": {
     "@joi/date": "^2.1.0",


### PR DESCRIPTION
The default timeout of jest is 5 seconds. Due to the mongodb or other slow operations, this timeout can be exceeded, so it was increased the timeout to 20000 ms in order to avoid those problems.